### PR TITLE
[TextInput-1087] Fix placeholder visibility on init

### DIFF
--- a/Sources/Core/TextEditor/ViewModel/TextEditorViewModel.swift
+++ b/Sources/Core/TextEditor/ViewModel/TextEditorViewModel.swift
@@ -14,7 +14,7 @@ final class TextEditorViewModel: TextInputViewModel {
 
     // MARK: - Published Properties
 
-    @Published private(set) var shouldShowPlaceholder: Bool = false
+    @Published private(set) var shouldShowPlaceholder: Bool = true
     @Published private(set) var updateVerticalSpacingCounter: Int = 0
 
     // MARK: - Private Properties

--- a/Tests/UnitTests/TextEditor/ViewModel/TextEditorViewModelTests.swift
+++ b/Tests/UnitTests/TextEditor/ViewModel/TextEditorViewModelTests.swift
@@ -56,7 +56,7 @@ final class TextEditorViewModelTests: XCTestCase {
         TextEditorViewModelPublisherTest.XCTAssert(
             shouldShowPlaceholder: stub.shouldShowPlaceholderPublisherMock,
             expectedNumberOfSinks: 1,
-            expectedValue: false
+            expectedValue: true
         )
         // **
 


### PR DESCRIPTION
The placeholder is not visible when the consumer set a value.
It works only when a text is set or if the component is focused.

**This PR solved this issue.**