### PR TITLE
[Fix] Revert modification on ViewModel publisher

### DIFF
--- a/Sources/Core/Common/ViewModel/TextInputViewModel.swift
+++ b/Sources/Core/Common/ViewModel/TextInputViewModel.swift
@@ -19,8 +19,8 @@ class TextInputViewModel: ObservableObject {
     // Colors
     @Published private(set) var textColor: any ColorToken
     @Published private(set) var placeholderColor: any ColorToken
-    @Published private(set) var borderColor: any ColorToken
-    @Published private(set) var backgroundColor: any ColorToken
+    @Published var borderColor: any ColorToken
+    @Published var backgroundColor: any ColorToken
 
     // BorderLayout
     @Published private(set) var borderRadius: CGFloat


### PR DESCRIPTION
The last release contains an UI bug on the AddonsTextField, the background when the component is disabled is not equals to 100% of the width...
![failure_1_446F3017-BC29-4CEC-9087-2CEC943B55F4](https://github.com/user-attachments/assets/89eca746-081f-49b4-a729-54ce47fce6fa)
